### PR TITLE
Fix ability to sort without overriding labels

### DIFF
--- a/bacon/cubedef.py
+++ b/bacon/cubedef.py
@@ -282,7 +282,8 @@ class Label(object):
 			self.unparse = unparse
 
 		self.acc = acc or accs.Group
-		self.key = key or (lambda _: "")
+		if key is not None:
+			self.key = key
 		self.reverse = reverse
 
 		self.child_of = child_of
@@ -299,6 +300,13 @@ class Label(object):
 		self.django_prefetch_related = django_prefetch_related
 
 		self.rank = 0
+
+	def key(self, value):
+		# Generic key function for nullable types which puts nulls first.
+		if value is None:
+			return ()
+		else:
+			return (value,)
 
 	def get_filter_op(self):
 		return 'eq'

--- a/bacon/cutting.py
+++ b/bacon/cutting.py
@@ -622,7 +622,7 @@ class Slice(object):
 		il = list(enumerate(labels))
 		il.reverse()
 		for i, l in il:
-			key = (lambda vs: l.key(vs[i])) if l.key is not None else None
+			key = lambda vs: l.key(vs[i])
 			values.sort(key=key, reverse=l.reverse)
 
 		for vs in values:


### PR DESCRIPTION
Basically, for any label without an overridden key, we sorted on the
empty string instead. Since no labels use this in the main package,
I cannot see how any non-overridden sort ever worked.