### PR TITLE
Drop support for python 2

### DIFF
--- a/bacon/accumulators.py
+++ b/bacon/accumulators.py
@@ -46,11 +46,11 @@ class Sum(Accumulator):
         return self
 
     def __repr__(self):
-        return "<%s (%r) at 0x%08X>" % (self.__class__.__name__, self.acc, id(self))
+        return f"<{self.__class__.__name__} ({self.acc!r}) at 0x{id(self):08X}>"
 
     @classmethod
     def manipulate_sql(self, sql, column, expression):
-        return sql.add_aggregate(column, "sum(%s)" % expression)
+        return sql.add_aggregate(column, f"sum({expression})")
 
 
 class Union(Accumulator):
@@ -105,7 +105,7 @@ class Max(Accumulator):
         return self
 
     def __repr__(self):
-        return "<%s (%r) at 0x%08X>" % (self.__class__.__name__, self.acc, id(self))
+        return f"<{self.__class__.__name__} ({self.acc!r}) at 0x{id(self):08X}>"
 
 
 class Min(Accumulator):
@@ -134,7 +134,7 @@ class Min(Accumulator):
         return self
 
     def __repr__(self):
-        return "<%s (%r) at 0x%08X>" % (self.__class__.__name__, self.acc, id(self))
+        return f"<{self.__class__.__name__} ({self.acc!r}) at 0x{id(self):08X}>"
 
 
 class Count(Accumulator):
@@ -154,7 +154,7 @@ class Count(Accumulator):
         return self
 
     def __repr__(self):
-        return "<%s (%r) at 0x%08X>" % (self.__class__.__name__, self.acc, id(self))
+        return f"<{self.__class__.__name__} ({self.acc!r}) at 0x{id(self):08X}>"
 
 
 class Average(Accumulator):
@@ -190,7 +190,7 @@ class Average(Accumulator):
         return self
 
     def __repr__(self):
-        return "<%s (%r items) at 0x%08X>" % (self.__class__.__name__, self.n, id(self))
+        return f"<{self.__class__.__name__} ({self.n!r} items) at 0x{id(self):08X}>"
 
 
 class StdDev(Accumulator):
@@ -231,7 +231,7 @@ class StdDev(Accumulator):
         return Inconsistent
 
     def __repr__(self):
-        return "<%s (%r items) at 0x%08X>" % (self.__class__.__name__, self.n, id(self))
+        return f"<{self.__class__.__name__} ({self.n!r} items) at 0x{id(self):08X}>"
 
 
 class _Unused(Accumulator):
@@ -296,7 +296,7 @@ class Group(Accumulator):
         return self
 
     def __repr__(self):
-        return "<%s (%r) at 0x%08X>" % (self.__class__.__name__, self.val, id(self))
+        return f"<{self.__class__.__name__} ({self.val!r}) at 0x{id(self):08X}>"
 
 
 def LabeledAcc(getter, acc):
@@ -385,11 +385,7 @@ def RatioSum(attr_num, attr_denom, expr_num=None, expr_denom=None):
             return self
 
         def __repr__(self):
-            return "<%s (%r) at 0x%08X>" % (
-                self.__class__.__name__,
-                self.accs,
-                id(self),
-            )
+            return f"<{self.__class__.__name__} ({self.accs!r}) at 0x{id(self):08X}>"
 
         @classmethod
         def manipulate_sql(self, sql, column, expression):

--- a/bacon/accumulators.py
+++ b/bacon/accumulators.py
@@ -2,7 +2,7 @@
 from math import sqrt
 
 
-class Accumulator(object):
+class Accumulator:
     def add(self, v, record):
         raise NotImplementedError
 

--- a/bacon/accumulators.py
+++ b/bacon/accumulators.py
@@ -1,7 +1,4 @@
 """Object to accumulate values"""
-
-from __future__ import division
-
 from math import sqrt
 
 

--- a/bacon/builders/__init__.py
+++ b/bacon/builders/__init__.py
@@ -1,7 +1,7 @@
 """Package containing builders to build query from string representations."""
 
 
-class QueryBuilder(object):
+class QueryBuilder:
     """Builds a query from a string representation.
 
     The class can also return the string representation of a query from a context.

--- a/bacon/builders/url.py
+++ b/bacon/builders/url.py
@@ -46,7 +46,7 @@ class UrlQueryBuilder(QueryBuilder):
         self, context, cubedef=None, base_url=None, query_location=IN_QUERY, **kwargs
     ):
         """The context should be a parameters mapping."""
-        super(UrlQueryBuilder, self).__init__(context, cubedef, **kwargs)
+        super().__init__(context, cubedef, **kwargs)
         self.base_url = base_url if base_url is not None else "."
         self.query_dict = context
         self.query_location = query_location

--- a/bacon/builders/url.py
+++ b/bacon/builders/url.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote_plus
+
 from bacon.builders import QueryBuilder
 from bacon import errors
 from bacon.utils.strings import (
@@ -5,7 +7,6 @@ from bacon.utils.strings import (
     bsunescape,
     bssplit,
     ensure_unicode,
-    quote_plus,
 )
 from bacon.constants import MULTI_ARG_OPS
 

--- a/bacon/builders/url.py
+++ b/bacon/builders/url.py
@@ -20,9 +20,9 @@ def encode_query(q):
         k = quote_plus(k)
         if isinstance(vv, list):
             for v in vv:
-                rv.append("%s=%s" % (k, quote_plus(v, safe=":/")))
+                rv.append(f"{k}={quote_plus(v, safe=':/')}")
         else:
-            rv.append("%s=%s" % (k, quote_plus(vv, safe=":/")))
+            rv.append(f"{k}={quote_plus(vv, safe=':/')}")
 
     return "&".join(rv)
 
@@ -60,7 +60,7 @@ class UrlQueryBuilder(QueryBuilder):
             tokens = bssplit(chunk, ":")
             cmd = tokens.pop(0)
             if not hasattr(self, cmd):
-                raise errors.QueryError("unknown command: '%s'" % cmd)
+                raise errors.QueryError(f"unknown command: '{cmd}'")
 
             yield cmd, list(map(bsunescape, tokens))
 
@@ -102,7 +102,7 @@ class UrlQueryBuilder(QueryBuilder):
 
         else:
             raise errors.QueryError(
-                "bad number of arguments for a filter: %d" % len(args)
+                f"bad number of arguments for a filter: {len(args)}"
             )
 
         # i have name, op, value here
@@ -145,7 +145,7 @@ class UrlQueryBuilder(QueryBuilder):
 
         else:
             raise ValueError(
-                "unexpected value for query_location: %r" % self.query_location
+                f"unexpected value for query_location: {self.query_location!r}"
             )
 
     # TODO: merge to_string and get_url
@@ -170,7 +170,7 @@ class UrlQueryBuilder(QueryBuilder):
 
         else:
             raise ValueError(
-                "unexpected value for query_location: %r" % self.query_location
+                f"unexpected value for query_location: {self.query_location!r}"
             )
 
     def to_string(self, query, name):
@@ -192,7 +192,7 @@ class UrlQueryBuilder(QueryBuilder):
             else:
                 op = ":" + op + ":"
 
-            yield "f:%s%s%s" % (str(name), str(op), value)
+            yield f"f:{str(name)}{str(op)}{value}"
 
         pivot = query.pivot
         for name in query.axes:

--- a/bacon/cubedef.py
+++ b/bacon/cubedef.py
@@ -14,19 +14,6 @@ from bacon.utils.strings import ensure_unicode
 from bacon.utils.dateutils import date_to_quarter
 
 
-try:
-    unicode
-except NameError:
-    # Python 3
-    def strftime_latin1(dateval, template):
-        return dateval.strftime(template.decode("latin1"))
-
-else:
-    # Python 2
-    def strftime_latin1(dateval, template):
-        return dateval.strftime(template).decode("latin1")
-
-
 class DataDef:
     """Definition of a dataset.
 
@@ -842,7 +829,7 @@ class MonthLabelMixin:
         return date(d.year, d.month, 1)
 
     def pretty(self, d, record=None):
-        return d and strftime_latin1(d, b"%b\xA0%Y") or "Unknown"
+        return d and d.strftime("%b\xA0%Y") or "Unknown"
 
     def parse(self, s):
         # parse -6 like "6 months ago"
@@ -987,7 +974,7 @@ class DayLabelMixin:
         return date(d.year, d.month, d.day)
 
     def pretty(self, d, record=None):
-        return d and strftime_latin1(d, b"%a\xA0%Y-%m-%d") or "Unknown"
+        return d and d.strftime("%a\xA0%Y-%m-%d") or "Unknown"
 
     def parse(self, s):
         # parse -30 like "30 days ago"
@@ -1046,7 +1033,7 @@ class HourLabel(DatetimeTruncLabel):
         return datetime(d.year, d.month, d.day, hour=getattr(d, "hour", 0))
 
     def pretty(self, d, record=None):
-        return d and strftime_latin1(d, b"%a\xA0%Y-%m-%dT%H") or "Unknown"
+        return d and d.strftime("%a\xA0%Y-%m-%dT%H") or "Unknown"
 
     def parse(self, s):
         # parse -30 like "30 hours ago"

--- a/bacon/cubedef.py
+++ b/bacon/cubedef.py
@@ -879,7 +879,8 @@ class QuarterLabelMixin:
     def pretty(self, d, record=None):
         if not d:
             return "Unknown"
-        return b"Q%d\xA0%d".decode("latin1") % ((d.month - 1) // 3 + 1, d.year)
+        quarter_num = (d.month - 1) // 3 + 1
+        return f"Q{quarter_num}\xA0{d.year}"
 
     def parse(self, s):
         # parse -1 like "1 quarter ago"

--- a/bacon/cubedef.py
+++ b/bacon/cubedef.py
@@ -504,25 +504,25 @@ class NullableLabel(Label):
     """A label that can handle None values outside the data type space."""
 
     def __init__(self, name, none_value="", none_label="(none)", **kwargs):
-        super(NullableLabel, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
         self.none_value = none_value
         self.none_label = none_label
 
     def pretty(self, value, record=None):
         if value is not None:
-            return super(NullableLabel, self).pretty(value, record)
+            return super().pretty(value, record)
         else:
             return self.none_label
 
     def parse(self, s):
         if s != self.none_value:
-            return super(NullableLabel, self).parse(s)
+            return super().parse(s)
         else:
             return None
 
     def unparse(self, v):
         if v is not None:
-            return super(NullableLabel, self).unparse(v)
+            return super().unparse(v)
         else:
             return self.none_value
 
@@ -538,7 +538,7 @@ class AttributeLabel(NullableLabel):
         self.attr = attr
         if "sql_expression" not in kwargs:
             kwargs["sql_expression"] = attr
-        super(AttributeLabel, self).__init__(name, extract=extract, **kwargs)
+        super().__init__(name, extract=extract, **kwargs)
 
 
 class SetLabel(NullableLabel):
@@ -668,7 +668,7 @@ class DatetimeTypeLabel(DatetimeDateTypeLabel):
     DATETIME_FORMAT = "%Y-%m-%dT%H:%M"
 
     def parse(self, s):
-        datetime_obj = super(DatetimeTypeLabel, self).parse(s)
+        datetime_obj = super().parse(s)
         if (
             datetime_obj.tzinfo is None
             or datetime_obj.tzinfo.utcoffset(datetime_obj) is None
@@ -679,7 +679,7 @@ class DatetimeTypeLabel(DatetimeDateTypeLabel):
 
 class DateTypeLabel(DatetimeDateTypeLabel):
     def parse(self, s):
-        return super(DateTypeLabel, self).parse(s).date()
+        return super().parse(s).date()
 
 
 class DatetimeDateHierarchyLabelMixin(DatetimeDateTypeLabel):
@@ -688,7 +688,7 @@ class DatetimeDateHierarchyLabelMixin(DatetimeDateTypeLabel):
 
     def __init__(self, name_or_field, **kwargs):
         self._title = kwargs.get("title", self.DEFAULT_TITLE)
-        super(DatetimeDateHierarchyLabelMixin, self).__init__(name_or_field, **kwargs)
+        super().__init__(name_or_field, **kwargs)
 
     def __unicode__(self):
         return self.title
@@ -739,7 +739,7 @@ _re_delta = re.compile(r"-?\d+$")
 
 class DatetimeDateTruncLabelMixin(DatetimeDateHierarchyLabelMixin):
     def add_sql_filter(self, sql, op, value):
-        sql = super(DatetimeDateTruncLabelMixin, self).add_sql_filter(sql, op, value)
+        sql = super().add_sql_filter(sql, op, value)
 
         if op in ("ge", "gt", "eq") and not isinstance(self, DayLabel):
             # Leave out Daylabel because it doesn't truncate.
@@ -853,7 +853,7 @@ class MonthLabelMixin(object):
             year, month = divmod(nmonths + int(s), 12)
             return date(year, month + 1, 1)
         else:
-            return super(MonthLabelMixin, self).parse(s)
+            return super().parse(s)
 
 
 class MonthLabel(MonthLabelMixin, DateTruncLabel):
@@ -900,7 +900,7 @@ class QuarterLabelMixin(object):
         if _re_delta.match(s):
             return date_to_quarter(date.today(), int(s))
         else:
-            d = super(QuarterLabelMixin, self).parse(s)
+            d = super().parse(s)
             return self.classify(d)
 
 
@@ -949,7 +949,7 @@ class WeekLabelMixin(object):
             day -= timedelta(days=day.isoweekday() - 1)  # first day of the week
             return day + timedelta(days=7 * int(s))
         else:
-            return super(WeekLabelMixin, self).parse(s)
+            return super().parse(s)
 
 
 class WeekLabel(WeekLabelMixin, DateTruncLabel):
@@ -995,7 +995,7 @@ class DayLabelMixin(object):
         if _re_delta.match(s):
             return date.today() + timedelta(days=int(s))
         else:
-            return super(DayLabelMixin, self).parse(s)
+            return super().parse(s)
 
     def to_excel(self, value, record=None):
         return value
@@ -1054,7 +1054,7 @@ class HourLabel(DatetimeTruncLabel):
         if _re_delta.match(s):
             return date.today() + timedelta(hours=int(s))
         else:
-            return super(HourLabel, self).parse(s)
+            return super().parse(s)
 
 
 class WeekdayLabel(DatetimePartLabel):
@@ -1092,7 +1092,7 @@ class Measure(Label):
     def __init__(self, name, cls="measure", show_by_default=True, **kwargs):
         if "acc" not in kwargs:
             kwargs["acc"] = accs.Sum
-        super(Measure, self).__init__(name, cls=cls, **kwargs)
+        super().__init__(name, cls=cls, **kwargs)
         self.show_by_default = show_by_default
 
     def add_sql_measure(self, sql):
@@ -1103,7 +1103,7 @@ class AttributeMeasure(Measure, AttributeLabel):
     def __init__(self, name, **kwargs):
         if "none_value" not in kwargs:
             kwargs["none_value"] = ""
-        super(AttributeMeasure, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
 
 
 class AttributeRatioMeasure(AttributeMeasure):
@@ -1127,4 +1127,4 @@ class AttributeRatioMeasure(AttributeMeasure):
             else:
                 return ratio
 
-        super(AttributeRatioMeasure, self).__init__(name, extract=ratio, **kwargs)
+        super().__init__(name, extract=ratio, **kwargs)

--- a/bacon/cubedef.py
+++ b/bacon/cubedef.py
@@ -274,7 +274,6 @@ class Label(object):
         allow_pivot=True,
         hidden=False,
     ):
-
         if isinstance(name_or_field, Field):
             self.field = name_or_field
             if extract:

--- a/bacon/cubedef.py
+++ b/bacon/cubedef.py
@@ -4,7 +4,6 @@ import re
 from calendar import day_name, month_name
 from datetime import date, datetime, timedelta
 from operator import attrgetter
-from six import string_types
 
 import networkx as nx
 
@@ -93,14 +92,14 @@ class CubeDef:
         self._graph.add_node(name)
 
         if label.child_of:
-            if isinstance(label.child_of, string_types):
+            if isinstance(label.child_of, str):
                 self.add_hierarchy(label.child_of, name)
             else:
                 for parent in label.child_of:
                     self.add_hierarchy(parent, name)
 
         if label.parent_of:
-            if isinstance(label.parent_of, string_types):
+            if isinstance(label.parent_of, str):
                 self.add_hierarchy(name, label.parent_of)
             else:
                 for child in label.parent_of:
@@ -225,7 +224,7 @@ class Field:
         return self.title
 
     def __eq__(self, other):
-        if not isinstance(other, string_types):
+        if not isinstance(other, str):
             other = other.name
         return self._name == other
 
@@ -299,7 +298,7 @@ class Label:
         self.parent_of = parent_of
         self.dimension = dimension
 
-        self.cls = isinstance(cls, string_types) and (lambda v, record: cls) or cls
+        self.cls = isinstance(cls, str) and (lambda v, record: cls) or cls
         self.allow_pivot = allow_pivot
         self.hidden = hidden
         self._sql_expression = sql_expression or self.field.name
@@ -349,7 +348,7 @@ class Label:
     def __eq__(self, other):
         if isinstance(other, type(self)):
             return self.field == other.field
-        elif isinstance(other, string_types):
+        elif isinstance(other, str):
             return self.field == other
         else:
             return None
@@ -554,7 +553,7 @@ class SetLabel(NullableLabel):
         return "hasonly"
 
     def pretty(self, value, record=None):
-        if isinstance(value, string_types):
+        if isinstance(value, str):
             return value
         elif value is None or value == ((None,)):
             return self.none_label

--- a/bacon/cubedef.py
+++ b/bacon/cubedef.py
@@ -28,7 +28,7 @@ else:
         return dateval.strftime(template).decode("latin1")
 
 
-class DataDef(object):
+class DataDef:
     """Definition of a dataset.
 
     The datadef is similar to a table schema in a relational database: it
@@ -56,7 +56,7 @@ class DataDef(object):
             yield Row(self, raw_object)
 
 
-class Row(object):
+class Row:
     """
     A simple wrapper that makes a row of data act like a dictionary,
     based on the DataDef fields.
@@ -70,7 +70,7 @@ class Row(object):
         return self.datadef[field_name].extract(self.raw)
 
 
-class CubeDef(object):
+class CubeDef:
     """Definition of a dataset and the different ways to read it.
 
     The cubedef extends the definition of the data beyond what you get
@@ -197,7 +197,7 @@ class CubeDef(object):
         return list(map(self.get_label, descendants(self._graph, name)))
 
 
-class Field(object):
+class Field:
     """
     A basic field that can extract and render data from a record.  If
     you want to filter on it, use the Label class instead.
@@ -245,7 +245,7 @@ class Field(object):
         return ensure_unicode(value)
 
 
-class Label(object):
+class Label:
     """Definition of a label on the records in a dataset.
 
     The label can be either subclassed or populated by init arguments.
@@ -797,7 +797,7 @@ class DatetimePartLabel(DatetimeDateHierarchyLabelMixin):
         return f"date_part('{self.SQL_DATE_FIELD}', {self._sql_expression})::integer"
 
 
-class YearLabelMixin(object):
+class YearLabelMixin:
     SUFFIX = "_year"
     DEFAULT_TITLE = "Year"
     DATETIME_FORMAT = "%Y"
@@ -832,7 +832,7 @@ class ISOYearLabel(DatetimePartLabel):
         return date.isocalendar()[0]
 
 
-class MonthLabelMixin(object):
+class MonthLabelMixin:
     SUFFIX = "_month"
     DEFAULT_TITLE = "Month"
     FORMAT = "%Y-%m"
@@ -880,7 +880,7 @@ class MonthOfYearLabel(DatetimePartLabel):
         return date.month
 
 
-class QuarterLabelMixin(object):
+class QuarterLabelMixin:
     SUFFIX = "_quarter"
     DEFAULT_TITLE = "Quarter"
     DATETIME_FORMAT = "%Y-%m"
@@ -925,7 +925,7 @@ class QuarterNumLabel(DatetimePartLabel):
         return ((date.month - 1) // 3 * 3) + 1
 
 
-class WeekLabelMixin(object):
+class WeekLabelMixin:
     SUFFIX = "_week"
     DEFAULT_TITLE = "Week"
     FORMAT = "%Y-%m-%d"
@@ -977,7 +977,7 @@ class ISOWeekNumLabel(DatetimePartLabel):
         return date.isocalendar()[1]
 
 
-class DayLabelMixin(object):
+class DayLabelMixin:
     SUFFIX = "_day"
     DEFAULT_TITLE = "Day"
     FORMAT = "%Y-%m-%d"

--- a/bacon/cubenav.py
+++ b/bacon/cubenav.py
@@ -3,10 +3,8 @@ from operator import attrgetter
 
 try:
     from itertools import imap
-
-    text_type = unicode
 except ImportError:
-    text_type = str
+    pass
 
 from bacon.cubequery import CubeQuery
 from collections import namedtuple
@@ -128,8 +126,8 @@ class Navigator:
                 name=name,
                 op=op,
                 value=value,
-                str_value=text_type(value),
-                pretty_name=text_type(label),
+                str_value=str(value),
+                pretty_name=str(label),
                 pretty_op=self._pretty_op.get(op, op),
                 pretty_value=pretty_value,
                 query_without=query.remove_filter(name, value, op),

--- a/bacon/cubenav.py
+++ b/bacon/cubenav.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python
 from operator import attrgetter
-
-try:
-    from itertools import imap
-except ImportError:
-    pass
-
 from bacon.cubequery import CubeQuery
 from collections import namedtuple
 from bacon.constants import MULTI_ARG_OPS

--- a/bacon/cubenav.py
+++ b/bacon/cubenav.py
@@ -23,7 +23,7 @@ CurrentFilter = namedtuple(
 )
 
 
-class Navigator(object):
+class Navigator:
     """Allows interactive navigation around a dataset."""
 
     def __init__(self, name, builder, cubedef):
@@ -277,7 +277,7 @@ class Navigator(object):
         return query
 
 
-class UrlMaker(object):
+class UrlMaker:
     """
     Helper mixin to make urls from something that has get_url and a navigator.
     """

--- a/bacon/cubenav.py
+++ b/bacon/cubenav.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-
-from __future__ import division
-
 from operator import attrgetter
 
 try:

--- a/bacon/cubequery.py
+++ b/bacon/cubequery.py
@@ -54,7 +54,7 @@ def related_ops(op):
     return set()
 
 
-class CubeQuery(object):
+class CubeQuery:
     def __init__(self):
         self._axes = []
         self._values = []

--- a/bacon/cubequery.py
+++ b/bacon/cubequery.py
@@ -64,7 +64,7 @@ class CubeQuery(object):
         self._pivots = set()
 
     def __repr__(self):
-        return "<%s dim=%s at 0x%08X>" % (self.__class__.__name__, self.dim, id(self))
+        return f"<{self.__class__.__name__} dim={self.dim} at 0x{id(self):08X}>"
 
     def copy(self):
         """Return a deep copy of the query."""

--- a/bacon/cutting.py
+++ b/bacon/cutting.py
@@ -4,10 +4,6 @@ import operator
 from copy import copy, deepcopy
 from functools import wraps
 
-try:
-    from itertools import ifilter
-except ImportError:
-    ifilter = filter
 from threading import RLock
 from collections import defaultdict, deque
 
@@ -20,12 +16,6 @@ import logging
 
 logger = logging.getLogger("bacon.cutting")
 logger.setLevel(logging.INFO)
-
-
-try:
-    xrange
-except NameError:
-    xrange = range
 
 
 class CuttingBoard:
@@ -76,7 +66,7 @@ class CuttingBoard:
         # Filter the dataset if required
         filter_p = _make_filter_predicate(query, self.cubedef)
         if filter_p is not None:
-            dataset = ifilter(filter_p, dataset)
+            dataset = filter(filter_p, dataset)
 
         return dataset
 
@@ -90,7 +80,7 @@ class CuttingBoard:
         # Filter the dataset if required
         filter_p = _make_filter_predicate(query, self.cubedef)
         if filter_p is not None:
-            dataset = ifilter(filter_p, dataset)
+            dataset = filter(filter_p, dataset)
 
         return self._fill_slice(slice, query, dataset)
 
@@ -396,7 +386,7 @@ class ManipulateSlice(SliceReuseStrategy):
 
         ds = self._unroll(slice)
         if filter_p is not None:
-            ds = ifilter(filter_p, ds)
+            ds = filter(filter_p, ds)
 
         bins = {}
         for okey, acc in ds:
@@ -499,11 +489,11 @@ class ManipulateSlice(SliceReuseStrategy):
 			return %(ps)s
 		"""
                 % {
-                    "idxs": ", ".join("idx%d=idxs[%d]" % (i, i) for i in xrange(L)),
-                    "vs": ", ".join("v%d=vs[%d]" % (i, i) for i in xrange(L)),
-                    "ops": ", ".join("op%d=ops[%d]" % (i, i) for i in xrange(L)),
+                    "idxs": ", ".join("idx%d=idxs[%d]" % (i, i) for i in range(L)),
+                    "vs": ", ".join("v%d=vs[%d]" % (i, i) for i in range(L)),
+                    "ops": ", ".join("op%d=ops[%d]" % (i, i) for i in range(L)),
                     "ps": " and ".join(
-                        "op%d(key[idx%d], v%d)" % (i, i, i) for i in xrange(L)
+                        "op%d(key[idx%d], v%d)" % (i, i, i) for i in range(L)
                     ),
                 }
             ),
@@ -720,7 +710,7 @@ def _make_acc_function(query, cubedef):
 	"""
         % {
             "accs": ", ".join(
-                "a%d=labels[%d].acc" % (i, i) for i in xrange(len(labels))
+                "a%d=labels[%d].acc" % (i, i) for i in range(len(labels))
             ),
             "items": ", ".join(
                 "%r: a%d()" % (label.name, i) for i, label in enumerate(labels)
@@ -740,7 +730,7 @@ def _make_acc_function(query, cubedef):
 	"""
                 % {
                     "es": ", ".join(
-                        "e%d=labels[%d].extract" % (i, i) for i in xrange(len(labels))
+                        "e%d=labels[%d].extract" % (i, i) for i in range(len(labels))
                     ),
                     "adds": "\n".join(
                         "\t\tacc[%r].add(e%d(record), record)" % (label.name, i)
@@ -908,11 +898,11 @@ def _make_filter_predicate(query, cubedef):
 		return %(ps)s
 	"""
             % {
-                "es": ", ".join("e%d=es[%d]" % (i, i) for i in xrange(L)),
-                "vs": ", ".join("v%d=vs[%d]" % (i, i) for i in xrange(L)),
-                "ops": ", ".join("op%d=ops[%d]" % (i, i) for i in xrange(L)),
+                "es": ", ".join("e%d=es[%d]" % (i, i) for i in range(L)),
+                "vs": ", ".join("v%d=vs[%d]" % (i, i) for i in range(L)),
+                "ops": ", ".join("op%d=ops[%d]" % (i, i) for i in range(L)),
                 "ps": " and ".join(
-                    "op%d(e%d(record), v%d)" % (i, i, i) for i in xrange(L)
+                    "op%d(e%d(record), v%d)" % (i, i, i) for i in range(L)
                 ),
             }
         ),

--- a/bacon/cutting.py
+++ b/bacon/cutting.py
@@ -1,6 +1,4 @@
 """Define what a cutting board and a slice are."""
-from __future__ import with_statement
-
 import re
 import operator
 from copy import copy, deepcopy

--- a/bacon/cutting.py
+++ b/bacon/cutting.py
@@ -30,7 +30,7 @@ except NameError:
     text_type = str
 
 
-class CuttingBoard(object):
+class CuttingBoard:
     """Allows observing a dataset according to the rules defined by a cubedef.
 
     `dataset` can be any iterable of python object, or callable returning one.
@@ -214,7 +214,7 @@ class CuttingBoard(object):
         d.appendleft(item)
 
 
-class SliceReuseStrategy(object):
+class SliceReuseStrategy:
     """Interface for strategies to use slices to create new slices."""
 
     def __init__(self, query):
@@ -534,7 +534,7 @@ class ManipulateSlice(SliceReuseStrategy):
 CuttingBoard.reuse_strategies.append(ManipulateSlice)
 
 
-class Slice(object):
+class Slice:
     """Accumulation in a dataset's values along some of its labels."""
 
     _lock = RLock()
@@ -657,7 +657,7 @@ class Slice(object):
         return self._zero_f()
 
 
-class LabeledValue(object):
+class LabeledValue:
     __slots__ = ["label", "value", "record"]
 
     def __init__(self, label, value, record=None):

--- a/bacon/cutting.py
+++ b/bacon/cutting.py
@@ -126,7 +126,7 @@ class CuttingBoard(object):
             root = bins[()]
 
         slice._data = root
-        logger.debug("NEW: slice %s for query %s" % (slice._ident, query.__dict__))
+        logger.debug(f"NEW: slice {slice._ident} for query {query.__dict__}")
         return slice
 
     def _make_empty_slice(self, query):
@@ -481,7 +481,7 @@ class ManipulateSlice(SliceReuseStrategy):
             try:
                 op = _op_map[op]
             except KeyError:
-                raise errors.QueryError("unknown operator: '%s'" % op)
+                raise errors.QueryError(f"unknown operator: '{op}'")
 
             # we know for compatibility that the filter is on one of the slice axes
             idxs.append(qold.axes.index(name))
@@ -552,11 +552,11 @@ class Slice(object):
         self._zero_f, self._acc_f = _make_acc_function(query, cubedef)
 
         with Slice._lock:
-            self._ident = "s-%s" % Slice._n
+            self._ident = f"s-{Slice._n}"
             Slice._n += 1
 
     def __repr__(self):
-        return "<%s dim=%s at 0x%08X>" % (self.__class__.__name__, self.dim, id(self))
+        return f"<{self.__class__.__name__} dim={self.dim} at 0x{id(self):08X}>"
 
     def __getitem__(self, idx):
         """Remove one of the slice axes.
@@ -892,7 +892,7 @@ def _make_filter_predicate(query, cubedef):
         try:
             op = _op_map[op]
         except KeyError:
-            raise errors.QueryError("unknown operator: '%s'" % op)
+            raise errors.QueryError(f"unknown operator: '{op}'")
 
         es.append(cubedef.get_label(name).extract)
         ops.append(op)

--- a/bacon/cutting.py
+++ b/bacon/cutting.py
@@ -24,10 +24,8 @@ logger.setLevel(logging.INFO)
 
 try:
     xrange
-    text_type = unicode
 except NameError:
     xrange = range
-    text_type = str
 
 
 class CuttingBoard:
@@ -690,10 +688,10 @@ class LabeledValue:
         return self.label.cls(self.value, self.record)
 
     def __unicode__(self):
-        return text_type(self.pretty)
+        return str(self.pretty)
 
     def __str__(self):
-        return text_type(self.pretty)
+        return str(self.pretty)
 
     @property
     def excel(self):

--- a/bacon/django/builder.py
+++ b/bacon/django/builder.py
@@ -10,4 +10,4 @@ class DjangoQueryBuilder(UrlQueryBuilder):
         # the context here is a Django request
         query_dict = context.GET if context.method == "GET" else context.POST
         query_dict = query_dict.copy()  # make it modifiable
-        super(DjangoQueryBuilder, self).__init__(query_dict, cubedef=cubedef, **kwargs)
+        super().__init__(query_dict, cubedef=cubedef, **kwargs)

--- a/bacon/django/json.py
+++ b/bacon/django/json.py
@@ -1,7 +1,4 @@
 """Render a json result in Django."""
-
-from __future__ import absolute_import
-
 from django.http import HttpResponse
 from django.conf import settings
 

--- a/bacon/django/sql.py
+++ b/bacon/django/sql.py
@@ -9,7 +9,7 @@ class DjangoConnectionFactory(BaseConnectionFactory):
 
     def __init__(self, db_name=None):
         self.db_name = db_name
-        super(DjangoConnectionFactory, self).__init__()
+        super().__init__()
 
     def getconn(self):
         if self.db_name is None:

--- a/bacon/django/templatetags/bacon_nav.py
+++ b/bacon/django/templatetags/bacon_nav.py
@@ -6,7 +6,7 @@ register = template.Library()
 
 @register.simple_tag
 def widget(panel, widget):
-    f = globals().get("render_%s" % widget.__class__.__name__, render_widget)
+    f = globals().get(f"render_{widget.__class__.__name__}", render_widget)
     return f(panel, widget)
 
 
@@ -38,7 +38,7 @@ def render_StringFilterWidget(panel, widget):
         widget,
         urls=urls,
         value=value or "",
-        unique="bacon_string_filter_{}".format(widget.axis),
+        unique=f"bacon_string_filter_{widget.axis}",
     )
 
 
@@ -53,7 +53,7 @@ def button(button, widget, panel):
 def render_widget(panel, widget, **kwargs):
     kwargs["panel"] = panel
     kwargs["widget"] = widget
-    tmpl = "bacon/nav/widgets/%s.tmpl" % widget.__class__.__name__
+    tmpl = f"bacon/nav/widgets/{widget.__class__.__name__}.tmpl"
     tmpl = template.loader.get_template(tmpl)
     if django.VERSION[:2] >= (1, 8):
         context = kwargs

--- a/bacon/django/templatetags/bacon_tags.py
+++ b/bacon/django/templatetags/bacon_tags.py
@@ -140,7 +140,7 @@ def debug(parser, token):
         tag, v = token.split_contents()
     except ValueError:
         raise template.TemplateSyntaxError(
-            "%r takes a single value" % token.contents.split()[0]
+            f"{token.contents.split()[0]!r} takes a single value"
         )
 
     return DebugNode(v)

--- a/bacon/flask/builder.py
+++ b/bacon/flask/builder.py
@@ -13,4 +13,4 @@ class FlaskQueryBuilder(UrlQueryBuilder):
         else:
             raise NotImplementedError(f"method {context.method} not supported")
 
-        super(FlaskQueryBuilder, self).__init__(query_dict, cubedef=cubedef, **kwargs)
+        super().__init__(query_dict, cubedef=cubedef, **kwargs)

--- a/bacon/flask/builder.py
+++ b/bacon/flask/builder.py
@@ -11,6 +11,6 @@ class FlaskQueryBuilder(UrlQueryBuilder):
         if context.method == "GET":
             query_dict = dict(context.args.items())
         else:
-            raise NotImplementedError("method %s not supported" % context.method)
+            raise NotImplementedError(f"method {context.method} not supported")
 
         super(FlaskQueryBuilder, self).__init__(query_dict, cubedef=cubedef, **kwargs)

--- a/bacon/flask/csv.py
+++ b/bacon/flask/csv.py
@@ -1,11 +1,12 @@
 """Render a csv file in Flask."""
-import six
+from io import StringIO
+
 from flask import Response
 
 import bacon.observers.csv
 
 
 def render_csv(request, table, **kwargs):
-    file = six.StringIO()
-    bacon.observers.csv.render_csv(file, table, **kwargs)
-    return Response(file.getvalue(), content_type="text/csv")
+    with StringIO() as csvfile:
+        bacon.observers.csv.render_csv(csvfile, table, **kwargs)
+        return Response(csvfile.getvalue(), content_type="text/csv")

--- a/bacon/flask/excel.py
+++ b/bacon/flask/excel.py
@@ -1,13 +1,13 @@
 """Render a xlwt workbook in Flask."""
+from io import BytesIO
 
-import six
 from flask import Response
 
 import bacon.observers.excel
 
 
 def render_excel(request, table, **kwargs):
-    wb = bacon.observers.excel.render_excel(table, **kwargs)
-    file = six.BytesIO()
-    wb.save(file)
-    return Response(file.getvalue(), content_type="aplication/vnd.ms-excel")
+    wbook = bacon.observers.excel.render_excel(table, **kwargs)
+    with BytesIO() as xlsfile:
+        wbook.save(xlsfile)
+        return Response(xlsfile.getvalue(), content_type="aplication/vnd.ms-excel")

--- a/bacon/flask/json.py
+++ b/bacon/flask/json.py
@@ -1,7 +1,4 @@
 """Render a json result in Flask."""
-
-from __future__ import absolute_import
-
 import json
 import flask
 import bacon.observers.json

--- a/bacon/observers/__init__.py
+++ b/bacon/observers/__init__.py
@@ -75,7 +75,7 @@ class Controller(object):
         try:
             return self.cutboard.slice(query)
         except (TypeError, AttributeError, KeyError) as e:
-            msg = "%s: %s" % (e.__class__.__name__, e)
+            msg = f"{e.__class__.__name__}: {e}"
             six.reraise(Exception, Exception(msg))
 
     def get_value(self, param):

--- a/bacon/observers/__init__.py
+++ b/bacon/observers/__init__.py
@@ -26,7 +26,7 @@ from bacon.cubequery import CubeQuery
 from bacon.cubenav import Navigator
 
 
-class Controller(object):
+class Controller:
     def __init__(self, name, builder, cutboard):
         self.name = name
         self.builder = builder
@@ -82,7 +82,7 @@ class Controller(object):
         return self.builder.get_value(param)
 
 
-class Viewer(object):
+class Viewer:
     def __init__(self, name, controller):
         self.name = name
         self.controller = controller

--- a/bacon/observers/__init__.py
+++ b/bacon/observers/__init__.py
@@ -20,8 +20,6 @@ may provide a mixin with the report logic and use it to create CustomizedTable,
 CustomizedPlot etc.
 """
 
-import six
-
 from bacon.cubequery import CubeQuery
 from bacon.cubenav import Navigator
 
@@ -75,8 +73,7 @@ class Controller:
         try:
             return self.cutboard.slice(query)
         except (TypeError, AttributeError, KeyError) as e:
-            msg = f"{e.__class__.__name__}: {e}"
-            six.reraise(Exception, Exception(msg))
+            raise Exception(f"{e.__class__.__name__}: {e}") from e
 
     def get_value(self, param):
         return self.builder.get_value(param)

--- a/bacon/observers/_wswrapper.py
+++ b/bacon/observers/_wswrapper.py
@@ -9,7 +9,7 @@ except NameError:
     text_types = (str,)
 
 
-class Styles(object):
+class Styles:
     default = xlwt.easyxf("align: horiz center")
     title = xlwt.easyxf("font: bold on; align: horiz center")
     money = xlwt.easyxf("align: horiz right", num_format_str="#,##0.00")
@@ -26,13 +26,13 @@ class Styles(object):
     datetime = xlwt.easyxf(num_format_str="ddy/mm/yyyy hh:mm")
 
 
-class ColType(object):
+class ColType:
     def __init__(self, style=Styles.default, converter=lambda x: x):
         self.style = style
         self.converter = converter
 
 
-class Table(object):
+class Table:
     def __init__(self, col_defs):
         self.col_defs = col_defs
 
@@ -48,7 +48,7 @@ class Table(object):
         ws.newline()
 
 
-class WSWrapper(object):
+class WSWrapper:
     """
     Helper to add functionality to xlwt worksheet object.  Keeps track
     of row and column positions so you don't have to.

--- a/bacon/observers/csv.py
+++ b/bacon/observers/csv.py
@@ -1,7 +1,4 @@
 """Export tables into CSV files."""
-
-from __future__ import absolute_import
-
 import csv
 from datetime import date
 from six.moves import xrange

--- a/bacon/observers/csv.py
+++ b/bacon/observers/csv.py
@@ -1,8 +1,6 @@
 """Export tables into CSV files."""
 import csv
 from datetime import date
-from six.moves import xrange
-from six import text_type, binary_type, PY2, PY3
 
 from bacon.observers.tables import Table1D, TablePivot
 
@@ -33,10 +31,7 @@ class CSVWrapper:
         elif isinstance(data, date):
             data = str(data)
 
-        elif PY2 and isinstance(data, text_type):
-            data = data.encode("utf8")
-
-        elif PY3 and isinstance(data, binary_type):
+        elif isinstance(data, bytes):
             data = data.decode("utf8")
 
         else:
@@ -46,7 +41,7 @@ class CSVWrapper:
 
     def write_merge(self, colspan, data, **kwargs):
         self.write(data)
-        for i in xrange(colspan - 1):
+        for i in range(colspan - 1):
             self.row.append("")
 
     def newline(self):
@@ -56,9 +51,9 @@ class CSVWrapper:
 
 def render_table_1d(ws, table):
     for t in table.label_titles():
-        ws.write(text_type(t))
+        ws.write(str(t))
     for t in table.value_titles():
-        ws.write(text_type(t))
+        ws.write(str(t))
     ws.newline()
 
     for slice, labels, values in table.rows():
@@ -67,7 +62,7 @@ def render_table_1d(ws, table):
             if label and isinstance(label.value, date):
                 ws.write(label.value)
             else:
-                ws.write(text_type(label))
+                ws.write(str(label))
 
         for v in values:
             ws.write(v.value)
@@ -77,17 +72,17 @@ def render_table_1d(ws, table):
 def render_table_pivot(ws, table):
     # Pivot values lines
     for pivot_label, pivot_lvs in table.pivot_titles():
-        ws.write_merge(len(table.label_titles()), text_type(pivot_label))
+        ws.write_merge(len(table.label_titles()), str(pivot_label))
         for label in pivot_lvs:
-            ws.write_merge(len(table.value_titles()), text_type(label))
+            ws.write_merge(len(table.value_titles()), str(label))
         ws.newline()
 
     # Column titles line
     for t in table.label_titles():
-        ws.write(t and text_type(t) or None)
+        ws.write(str(t) if t else None)
     for label in table.pivot_lvs():
         for t in table.value_titles():
-            ws.write(text_type(t))
+            ws.write(str(t))
     ws.newline()
 
     # Table data
@@ -99,7 +94,7 @@ def render_table_pivot(ws, table):
             elif isinstance(label.value, date):
                 ws.write(label.value)
             else:
-                ws.write(text_type(label))
+                ws.write(str(label))
 
         for v in values:
             ws.write(v.value)

--- a/bacon/observers/csv.py
+++ b/bacon/observers/csv.py
@@ -20,7 +20,7 @@ def render_csv(file, table, **kwargs):
     return cw.writer
 
 
-class CSVWrapper(object):
+class CSVWrapper:
     """Wrap the csv writer for easier access."""
 
     def __init__(self, writer):

--- a/bacon/observers/excel.py
+++ b/bacon/observers/excel.py
@@ -22,7 +22,7 @@ def render_excel(table, title="Sheet"):
 
     ws.newline()
     ws.write(
-        "Report generated on %s" % datetime.datetime.now().strftime("%d/%m/%Y %H:%M"),
+        f"Report generated on {datetime.datetime.now().strftime('%d/%m/%Y %H:%M')}",
         # font height in 1/20th of points of course...
         style=xlwt.easyxf("font: height 160"),
     )

--- a/bacon/observers/json.py
+++ b/bacon/observers/json.py
@@ -42,7 +42,7 @@ def render_nav_json(panel):
                 [
                     (
                         "label",
-                        "%s %s %s" % (f.pretty_name, f.pretty_op, f.pretty_value),
+                        f"{f.pretty_name} {f.pretty_op} {f.pretty_value}",
                     ),
                     ("drop_url", panel.get_url(f.query_without)),
                     ("invert_url", panel.get_url(f.query_invert)),
@@ -107,7 +107,7 @@ def _render_widget(widget, panel):
         else:
             return f(rv, widget, panel)
 
-    raise NotImplementedError("can't render %r in json" % widget)
+    raise NotImplementedError(f"can't render {widget!r} in json")
 
 
 def _render_ButtonsWidget(rv, widget, panel):

--- a/bacon/observers/json.py
+++ b/bacon/observers/json.py
@@ -352,7 +352,7 @@ def _render_pages(table, link):
     return rv
 
 
-class LinkMap(object):
+class LinkMap:
     def __init__(self):
         self.count = count()
         self.links = OrderedDict()

--- a/bacon/observers/nav.py
+++ b/bacon/observers/nav.py
@@ -11,7 +11,7 @@ class NavPanel(Viewer):
         self.widgets = widgets or []
 
 
-class NavWidget(object):
+class NavWidget:
     """An object displayed in a `NavPanel` allowing customised navigation."""
 
     def __init__(self, label):
@@ -97,7 +97,7 @@ class ButtonsWidget(NavWidget):
         self.buttons = buttons
 
 
-class Button(object):
+class Button:
     """A button redirecting to a new query when clicked."""
 
     def __init__(self, label, image_url=None, builder=None):

--- a/bacon/observers/nav.py
+++ b/bacon/observers/nav.py
@@ -7,7 +7,7 @@ class NavPanel(Viewer):
     """A container for `NavWidget` to be rendered on an interface."""
 
     def __init__(self, name, controller, widgets=None, **kwargs):
-        super(NavPanel, self).__init__(name, controller, **kwargs)
+        super().__init__(name, controller, **kwargs)
         self.widgets = widgets or []
 
 
@@ -26,7 +26,7 @@ class DatesRangeWidget(NavWidget):
         if toolkit not in supported:
             raise ValueError("toolkit not supported: %s", toolkit)
 
-        super(DatesRangeWidget, self).__init__(label)
+        super().__init__(label)
         # axis is the name of one of the axis in the time dimension to handle
         # it should be rendered as a date (yyyy-mm-dd), so day or week is fine.
         self.axis = axis
@@ -71,7 +71,7 @@ class StringFilterWidget(NavWidget):
     """A widget allowing to filter on an axis."""
 
     def __init__(self, label, axis, op="eq"):
-        super(StringFilterWidget, self).__init__(label)
+        super().__init__(label)
         self.axis = axis
         self.op = op
 
@@ -93,7 +93,7 @@ class ButtonsWidget(NavWidget):
     """A widget container for `Button`."""
 
     def __init__(self, label, buttons):
-        super(ButtonsWidget, self).__init__(label)
+        super().__init__(label)
         self.buttons = buttons
 
 
@@ -117,7 +117,7 @@ class FixedQueryButton(Button):
     """A button that returns always the same query."""
 
     def __init__(self, label, query, **kwargs):
-        super(FixedQueryButton, self).__init__(label, **kwargs)
+        super().__init__(label, **kwargs)
         self._query = query
 
     def get_url(self, widget, panel):
@@ -130,7 +130,7 @@ class FilterButton(Button):
     REMOVE = "__REMOVE__"
 
     def __init__(self, label, axis, value, **kwargs):
-        super(FilterButton, self).__init__(label, **kwargs)
+        super().__init__(label, **kwargs)
         self.axis = axis
         self.value = value
 

--- a/bacon/observers/plot.py
+++ b/bacon/observers/plot.py
@@ -7,7 +7,7 @@ from bacon.observers import Viewer
 
 class Plot(Viewer):
     def __init__(self, name, controller, size=(640, 480), dpi=80, **kwargs):
-        super(Plot, self).__init__(name, controller, **kwargs)
+        super().__init__(name, controller, **kwargs)
         self.size = size
         self.dpi = dpi
 
@@ -34,7 +34,7 @@ class Plot(Viewer):
 
 class TimePlotData(Plot):
     def __init__(self, name, controller, **kwargs):
-        super(TimePlotData, self).__init__(name, controller, **kwargs)
+        super().__init__(name, controller, **kwargs)
 
     def _make_data(self):
         if hasattr(self, "_t"):

--- a/bacon/observers/plot.py
+++ b/bacon/observers/plot.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from operator import itemgetter
 
 from bacon.observers import Viewer

--- a/bacon/observers/tables.py
+++ b/bacon/observers/tables.py
@@ -232,7 +232,6 @@ class TableDetails(UrlMaker, BaseTableRenderer):
 
 
 class Table1D(UrlMaker, BaseTableRenderer):
-
     Row = namedtuple("Table1DRow", ["slice", "labels", "values"])
 
     def label_titles(self):
@@ -336,7 +335,6 @@ class Table1D(UrlMaker, BaseTableRenderer):
 
 
 class TablePivot(UrlMaker, BaseTableRenderer):
-
     Row = namedtuple("Table2DRow", ["slice", "labels", "values", "totals"])
 
     def __init__(self, table):

--- a/bacon/observers/tables.py
+++ b/bacon/observers/tables.py
@@ -342,7 +342,7 @@ class TablePivot(UrlMaker, BaseTableRenderer):
         self.pivot_labels = list(self.nav.pivot)
         for l in self.pivot_labels:
             if not l.allow_pivot:
-                raise errors.QueryError("can't pivot on %s" % l.name)
+                raise errors.QueryError(f"can't pivot on {l.name}")
 
     # TODO: everything that is not a method needs being an attribute. Django
     # doesn't need braces but other observers do

--- a/bacon/observers/tables.py
+++ b/bacon/observers/tables.py
@@ -148,7 +148,7 @@ class Table(PaginatedViewer):
         self._widgets[col_name].append(widget)
 
 
-class RowWidget(object):
+class RowWidget:
     def __init__(self, name, builder, label=None):
         self.name = name
         self.label = label or name
@@ -159,7 +159,7 @@ class RowWidget(object):
 # this must be specified somehow
 
 
-class BaseTableRenderer(object):
+class BaseTableRenderer:
     def __init__(self, table):
         self.table = table
         self._nrows = 0

--- a/bacon/observers/tables.py
+++ b/bacon/observers/tables.py
@@ -27,7 +27,7 @@ from bacon.utils import cache
 
 class PaginatedViewer(Viewer):
     def __init__(self, name, controller, page_size=None, **kwargs):
-        super(PaginatedViewer, self).__init__(name, controller, **kwargs)
+        super().__init__(name, controller, **kwargs)
         self.page_size = page_size
         self._nrows = None
 
@@ -144,7 +144,7 @@ class PaginatedViewer(Viewer):
 
 class Table(PaginatedViewer):
     def __init__(self, name, controller, **kwargs):
-        super(Table, self).__init__(name, controller, **kwargs)
+        super().__init__(name, controller, **kwargs)
         self._widgets = defaultdict(list)
 
     def add_widget(self, widget, col_name=None):
@@ -338,7 +338,7 @@ class TablePivot(UrlMaker, BaseTableRenderer):
     Row = namedtuple("Table2DRow", ["slice", "labels", "values", "totals"])
 
     def __init__(self, table):
-        super(TablePivot, self).__init__(table)
+        super().__init__(table)
         self.pivot_labels = list(self.nav.pivot)
         for l in self.pivot_labels:
             if not l.allow_pivot:

--- a/bacon/observers/tables.py
+++ b/bacon/observers/tables.py
@@ -2,16 +2,7 @@
 from math import ceil
 from itertools import chain
 
-try:
-    from itertools import izip
-except ImportError:
-    izip = zip
 from collections import defaultdict
-
-try:
-    xrange
-except NameError:
-    xrange = range
 
 from bacon import errors
 from bacon.observers import Viewer
@@ -101,13 +92,13 @@ class PaginatedViewer(Viewer):
 
         def run(start, end):
             if end - start < 7:
-                for n in xrange(start, end):
+                for n in range(start, end):
                     yield link(n)
             else:
-                for n in xrange(start, start + 2):
+                for n in range(start, start + 2):
                     yield link(n)
                 yield label("...")
-                for n in xrange(end - 2, end):
+                for n in range(end - 2, end):
                     yield link(n)
 
         return chain(
@@ -465,7 +456,7 @@ class TablePivot(UrlMaker, BaseTableRenderer):
 
     def _iter_row(self, slice, row_totals, col_totals):
         titles = self.value_titles()
-        for labels, ctot in izip(self.pivot_lvs(), col_totals):
+        for labels, ctot in zip(self.pivot_lvs(), col_totals):
             tmp_slice = slice
             try:
                 for label in labels:

--- a/bacon/observers/tables.py
+++ b/bacon/observers/tables.py
@@ -1,7 +1,4 @@
 """Objects to build visualizations of query slices."""
-
-from __future__ import division
-
 from math import ceil
 from itertools import chain
 

--- a/bacon/sql.py
+++ b/bacon/sql.py
@@ -19,7 +19,7 @@ except NameError:
     basestring = str, bytes
 
 
-class SqlQuery(object):
+class SqlQuery:
     def __init__(self):
         self._prequerylist = []
         self._ctelist = []
@@ -179,7 +179,7 @@ class SqlQuery(object):
         return args
 
 
-class BaseConnectionFactory(object):
+class BaseConnectionFactory:
     """An abstract object returning and disposing database connections."""
 
     def getconn(self):
@@ -342,7 +342,7 @@ class DjangoCuttingBoard(CuttingBoard):
         return queryset
 
 
-class RowsProxy(object):
+class RowsProxy:
     """A container to return a list of result still supporting pagination
 
     Used for the interaction with a DetailsTable.

--- a/bacon/sql.py
+++ b/bacon/sql.py
@@ -78,7 +78,7 @@ class SqlQuery(object):
 
         sql = deepcopy(self)
         sql._columns.add(column)
-        sql._selectlist.append("(%s) AS %s" % (expression, self.quote_ident(column)))
+        sql._selectlist.append(f"({expression}) AS {self.quote_ident(column)}")
         sql._grouplist.append(expression)
         return sql
 
@@ -93,7 +93,7 @@ class SqlQuery(object):
 
         sql = deepcopy(self)
         sql._columns.add(column)
-        sql._selectlist.append("(%s) AS %s" % (expression, self.quote_ident(column)))
+        sql._selectlist.append(f"({expression}) AS {self.quote_ident(column)}")
         return sql
 
     def add_filter(self, expression, *values):

--- a/bacon/sql.py
+++ b/bacon/sql.py
@@ -228,7 +228,7 @@ class SqlCuttingBoard(CuttingBoard):
         self.sql = sql
         self.connection_factory = connection_factory
 
-        super(SqlCuttingBoard, self).__init__(cubedef, dataset=())
+        super().__init__(cubedef, dataset=())
 
     @with_connection_method
     def _make_slice(self, cnn, query):
@@ -301,7 +301,7 @@ class DjangoCuttingBoard(CuttingBoard):
         self.only = set()
         self.select_related = set()
         self.prefetch_related = set()
-        super(DjangoCuttingBoard, self).__init__(cubedef, dataset=())
+        super().__init__(cubedef, dataset=())
 
     def _add_label(self, label):
         for select_related in label.django_select_related:

--- a/bacon/sql.py
+++ b/bacon/sql.py
@@ -13,11 +13,6 @@ import logging
 logger = logging.getLogger("bacon.sql")
 logger.setLevel(logging.DEBUG)
 
-try:
-    basestring
-except NameError:
-    basestring = str, bytes
-
 
 class SqlQuery:
     def __init__(self):
@@ -199,7 +194,7 @@ class ConnectionFactory(BaseConnectionFactory):
         self.dsn = dsn
 
     def getconn(self):
-        if isinstance(self.dsn, basestring):
+        if isinstance(self.dsn, str):
             return psycopg2.connect(self.dsn)
         else:
             return psycopg2.connect(**self.dsn)

--- a/bacon/utils/cache.py
+++ b/bacon/utils/cache.py
@@ -69,7 +69,7 @@ def cached_method(f):
     The decorator is not thread-safe. If needed use the `synchro_method`
     decorator to serialize access to the function.
     """
-    cache_name = "_cache_%s" % f.__name__
+    cache_name = f"_cache_{f.__name__}"
 
     @wraps(f)
     def cached_method_(self, *args):

--- a/bacon/utils/commas.py
+++ b/bacon/utils/commas.py
@@ -7,11 +7,6 @@ http://code.activestate.com/recipes/498181/ (r1)
 
 import re
 
-try:
-    xrange
-except NameError:
-    xrange = range
-
 __test__ = {}
 
 re_digits_nondigits = re.compile(r"\d+|\D+")
@@ -75,7 +70,7 @@ def FormatWithCommas(format, value):
     """
 
     parts = re_digits_nondigits.findall(format % (value,))
-    for i in xrange(len(parts)):
+    for i in range(len(parts)):
         s = parts[i]
         if s.isdigit():
             parts[i] = _commafy(s)

--- a/bacon/utils/logging_middleware.py
+++ b/bacon/utils/logging_middleware.py
@@ -55,7 +55,7 @@ class LoggingMiddleware(MiddlewareMixin):
             except ImportError:
                 pass
 
-        rv = super(LoggingMiddleware, cls).__new__(LoggingMiddleware)
+        rv = super().__new__(LoggingMiddleware)
         LoggingMiddleware.__init__(rv, **kwargs)
         return rv
 

--- a/bacon/utils/logging_middleware.py
+++ b/bacon/utils/logging_middleware.py
@@ -40,7 +40,7 @@ class LoggingMiddleware(MiddlewareMixin):
     format = (
         "%(REMOTE_ADDR)s - %(REMOTE_USER)s [%(time)s] "
         '"%(REQUEST_METHOD)s %(REQUEST_URI)s %(HTTP_VERSION)s" '
-        '%(status)s %(bytes)s "%(HTTP_REFERER)s" "%(HTTP_USER_AGENT)s"'
+        '%(status)s %(content_len)s "%(HTTP_REFERER)s" "%(HTTP_USER_AGENT)s"'
     )
 
     def __new__(cls, **kwargs):
@@ -117,18 +117,18 @@ class LoggingMiddleware(MiddlewareMixin):
         req_uri = request.get_full_path()
         method = request.method
 
-        bytes = response.get("Content-Length", None)
-        if bytes is None and isinstance(response.content, str):
-            bytes = len(response.content)
+        content_len = response.get("Content-Length", None)
+        if content_len is None and isinstance(response.content, str):
+            content_len = len(response.content)
 
         status_code = response.status_code
 
-        self.write_log(environ, method, req_uri, start, status_code, bytes)
+        self.write_log(environ, method, req_uri, start, status_code, content_len)
         return response
 
-    def write_log(self, environ, method, req_uri, start, status_code, bytes):
-        if bytes is None:
-            bytes = "-"
+    def write_log(self, environ, method, req_uri, start, status_code, content_len):
+        if content_len is None:
+            content_len = "-"
         if time.daylight:
             offset = time.altzone / 60 / 60 * -100
         else:
@@ -145,7 +145,7 @@ class LoggingMiddleware(MiddlewareMixin):
             "HTTP_VERSION": environ.get("SERVER_PROTOCOL"),
             "time": time.strftime("%d/%b/%Y:%H:%M:%S ", start) + offset,
             "status": status_code,
-            "bytes": bytes,
+            "content_len": content_len,
             "HTTP_REFERER": environ.get("HTTP_REFERER", "-"),
             "HTTP_USER_AGENT": environ.get("HTTP_USER_AGENT", "-"),
         }

--- a/bacon/utils/logging_middleware.py
+++ b/bacon/utils/logging_middleware.py
@@ -69,7 +69,6 @@ class LoggingMiddleware(MiddlewareMixin):
         set_logger_level=logging.DEBUG,
         disable_on_devel=True,
     ):
-
         # Because __init__ is called manually by __new__, it is invoked twice:
         # bail out early the second time as we are already configured.
         if self.__dict__:

--- a/bacon/utils/strings.py
+++ b/bacon/utils/strings.py
@@ -2,11 +2,6 @@
 
 import re
 
-try:
-    from urllib import quote_plus
-except ImportError:
-    from urllib.parse import quote_plus  # noqa -- for export
-
 
 def bssplit(s, sep, maxsplit=0):
     r"""Similare to ``s.split(sep)``, but avoid \-escaped sep."""

--- a/bacon/utils/strings.py
+++ b/bacon/utils/strings.py
@@ -34,43 +34,10 @@ def bsunescape(s, _rex=re.compile(r"\\(.)")):
     return _rex.sub(lambda m: m.group(1), s)
 
 
-try:
-    unicode
-except NameError:
-    # Python 3
-
-    basestring = str, bytes
-
-    def ensure_unicode(s):
-        if isinstance(s, bytes):
-            return s.decode("utf-8")
-        elif isinstance(s, str):
-            return s
-        else:
-            return str(s)
-
-    def ensure_bytes(s):
-        if isinstance(s, bytes):
-            return s
-        elif isinstance(s, str):
-            return s.encode("utf-8")
-        else:
-            return bytes(s)
-
-else:
-    # Python 2
-    def ensure_unicode(s):
-        if isinstance(s, str):
-            return s.decode("utf-8")
-        elif isinstance(s, unicode):
-            return s
-        else:
-            return unicode(s)
-
-    def ensure_bytes(s):
-        if isinstance(s, unicode):
-            return s.decode("utf-8")
-        elif isinstance(s, str):
-            return s
-        else:
-            return str(s)
+def ensure_unicode(s):
+    if isinstance(s, bytes):
+        return s.decode("utf-8")
+    elif isinstance(s, str):
+        return s
+    else:
+        return str(s)

--- a/bacon/utils/synchro.py
+++ b/bacon/utils/synchro.py
@@ -1,7 +1,4 @@
 """Decorators to synchronize objects access in multithread environment."""
-
-from __future__ import with_statement
-
 from functools import wraps
 
 

--- a/bacon_demo/bacon_sales/urls.py
+++ b/bacon_demo/bacon_sales/urls.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.conf.urls.defaults import *  # noqa
 
 from . import views

--- a/bacon_demo/bacon_sales/views.py
+++ b/bacon_demo/bacon_sales/views.py
@@ -21,7 +21,7 @@ class SalesTable(Table):
 
 class SalesPlot(TimePlotData):
     def get_query(self):
-        q = super(SalesPlot, self).get_query()
+        q = super().get_query()
 
         for name in q.pivot:
             q = q.unset_pivot(name)

--- a/bacon_demo/manage.py
+++ b/bacon_demo/manage.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import
 from django.core.management import execute_manager
 
 try:

--- a/bacon_demo/sales_ajax/urls.py
+++ b/bacon_demo/sales_ajax/urls.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.conf.urls import patterns
 
 from . import views

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=packages,
     zip_safe=False,
     include_package_data=True,
-    install_requires=["networkx>=1.1,<2.0", "six", "pytz"],
+    install_requires=["networkx>=1.1,<2.0", "pytz"],
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,5 @@ setup(
     install_requires=["networkx>=1.1,<2.0", "six", "pytz"],
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
+    python_requires=">=3.6",
 )

--- a/tests/test_cutboard.py
+++ b/tests/test_cutboard.py
@@ -48,27 +48,19 @@ class CubeDefTestCase(unittest.TestCase):
         slice = cb.slice(cq, flat=False)
         self.assertEqual(
             (180,),
-            slice[1,][
-                "apples",
-            ],
+            slice[1,]["apples",],
         )
         self.assertEqual(
             (101,),
-            slice[1,][
-                "pears",
-            ],
+            slice[1,]["pears",],
         )
         self.assertEqual(
             (50,),
-            slice[2,][
-                "apples",
-            ],
+            slice[2,]["apples",],
         )
         self.assertEqual(
             50,
-            slice[2,][
-                "apples",
-            ].number,
+            slice[2,]["apples",].number,
             "not a namedtuple",
         )
 
@@ -84,21 +76,15 @@ class CubeDefTestCase(unittest.TestCase):
         slice = cb.slice(cq, flat=False)
         self.assertEqual(
             (281,),
-            slice[
-                1,
-            ],
+            slice[1,],
         )
         self.assertEqual(
             (50,),
-            slice[
-                2,
-            ],
+            slice[2,],
         )
         self.assertEqual(
             50,
-            slice[
-                2,
-            ].number,
+            slice[2,].number,
             "not a namedtuple",
         )
 
@@ -114,15 +100,11 @@ class CubeDefTestCase(unittest.TestCase):
         slice = cb.slice(cq, flat=False)
         self.assertEqual(
             100,
-            slice[1, "italy"][
-                "apples",
-            ].number,
+            slice[1, "italy"]["apples",].number,
         )
         self.assertEqual(
             50,
-            slice[2, "italy"][
-                "apples",
-            ].number,
+            slice[2, "italy"]["apples",].number,
         )
 
     def test_slice_iteration(self):


### PR DESCRIPTION
Dropping python 2 will make it easier to do some future work.

(Future work would be to support python 3.9, which is currently broken because the `networkx < 2` dependency pin.)

This may break for people if:
- you use `bytes`. eg: this definitely breaks if you use bytes as the database dsn setting, but probably it breaks in a bunch of places
- if you subclass `LoggingMiddleware` to set a different `format` string, I changed `bytes` to `content_len`

This would make the library work with only:
- `python >= 3.6`, which is what I set in `setup.py`, although it probably works with earlier versions
- `python < 3.9` which is when networkx 1.x dependeny breaks things (I haven't fixed this yet)
