### PR TITLE
Fix tests for TypeErorr vs assert

### DIFF
--- a/tests/test_cubedef.py
+++ b/tests/test_cubedef.py
@@ -33,7 +33,7 @@ class LabelTestCase(unittest.TestCase):
 class CubeDefTestCase(unittest.TestCase):
     def test_labels_must_be_labels(self):
         cd = CubeDef()
-        self.assertRaises(TypeError, cd.add_label, "year")
+        self.assertRaises(AssertionError, cd.add_label, "year")
 
     def test_get_label(self):
         cd = CubeDef()
@@ -53,7 +53,7 @@ class CubeDefTestCase(unittest.TestCase):
 
     def test_measures_must_be_labels(self):
         cd = CubeDef()
-        self.assertRaises(TypeError, cd.add_measure, "num")
+        self.assertRaises(AssertionError, cd.add_measure, "num")
         cd.add_measure(Label("year"))
 
     def test_get_measure(self):

--- a/tests/test_utils_string.py
+++ b/tests/test_utils_string.py
@@ -14,7 +14,7 @@ class StringsTestCase(unittest.TestCase):
         self.assertEqual(r"foo\\bar\/baz", strings.bsescape(r"foo\bar/baz", "/"))
 
     def test_bsunescape(self):
-        self.assertEqual("foo/bar", strings.bsunescape("foo\/bar"))
+        self.assertEqual("foo/bar", strings.bsunescape(r"foo\/bar"))
         self.assertEqual(r"foo/bar\baz", strings.bsunescape(r"foo\/bar\\baz"))
 
     def test_bssplit(self):


### PR DESCRIPTION
In #7, I changed an `if isinstance(): raise TypeError()` to be an `assert`, and then didn't run the tests.

This fixes the tests.

I also fix a warning about an invalid `r"..."` string