### PR TITLE
Undo a change of `raise TypeError` -> `assert`

### DIFF
--- a/bacon/cubedef.py
+++ b/bacon/cubedef.py
@@ -73,7 +73,8 @@ class CubeDef:
 
     def add_label(self, label: Label) -> Label:
         """Add a new label definition."""
-        assert isinstance(label, Label)
+        if not isinstance(label, Label):
+            raise TypeError(f"expected 'Label' instance, {label!r} got instead")
 
         name = label.name
         self._labels[name] = label

--- a/tests/test_cubedef.py
+++ b/tests/test_cubedef.py
@@ -33,7 +33,7 @@ class LabelTestCase(unittest.TestCase):
 class CubeDefTestCase(unittest.TestCase):
     def test_labels_must_be_labels(self):
         cd = CubeDef()
-        self.assertRaises(AssertionError, cd.add_label, "year")
+        self.assertRaises(TypeError, cd.add_label, "year")
 
     def test_get_label(self):
         cd = CubeDef()
@@ -53,7 +53,7 @@ class CubeDefTestCase(unittest.TestCase):
 
     def test_measures_must_be_labels(self):
         cd = CubeDef()
-        self.assertRaises(AssertionError, cd.add_measure, "num")
+        self.assertRaises(TypeError, cd.add_measure, "num")
         cd.add_measure(Label("year"))
 
     def test_get_measure(self):


### PR DESCRIPTION
In #7 I changed a TypeError to an assert.

I mostly did this change because it matches the style I've seen when using `mypy`, and callers should probably get this right as it has a type hint.

Obviously that was a mistake, as pretty much the only thing the tests look for it that this raises TypeError.

This patch reverts that line from the #7, and also reverts a half-baked fix attempt in #8.