### PR TITLE
BoolTypeLabel: add `label_true` and `label_false` to allow styling

### DIFF
--- a/bacon/cubedef.py
+++ b/bacon/cubedef.py
@@ -632,6 +632,14 @@ class IntTypeLabel(Label):
 
 
 class BoolTypeLabel(Label):
+    def __init__(
+        self, *args, label_true="Yes", label_false="No", label_null="Unknown", **kwargs
+    ):
+        self.label_true = label_true
+        self.label_false = label_false
+        self.label_null = label_null
+        super().__init__(*args, **kwargs)
+
     def parse(self, s, _v={"0": False, "1": True, "": None}):
         # TODO, enforce, check, etc, raise a better error, etc
         return _v[s]
@@ -639,8 +647,14 @@ class BoolTypeLabel(Label):
     def unparse(self, v, _f={False: "0", True: "1", None: ""}):
         return _f[v]
 
-    def pretty(self, v, record=None, _f={False: "No", True: "Yes", None: "Unknown"}):
-        return _f[v]
+    def pretty(self, value, record=None):
+        if value is True:
+            return self.label_true
+        if value is False:
+            return self.label_false
+        if value is None:
+            return self.label_null
+        raise ValueError(value)
 
 
 class DatetimeDateTypeLabel(Label):

--- a/bacon/cubedef.py
+++ b/bacon/cubedef.py
@@ -640,12 +640,16 @@ class BoolTypeLabel(Label):
         self.label_null = label_null
         super().__init__(*args, **kwargs)
 
-    def parse(self, s, _v={"0": False, "1": True, "": None}):
-        # TODO, enforce, check, etc, raise a better error, etc
-        return _v[s]
+    _q_to_b = {"0": False, "1": True, "": None}
 
-    def unparse(self, v, _f={False: "0", True: "1", None: ""}):
-        return _f[v]
+    def parse(self, s):
+        # TODO, enforce, check, etc, raise a better error, etc
+        return self._q_to_b[s]
+
+    _b_to_q = {False: "0", True: "1", None: ""}
+
+    def unparse(self, v):
+        return self._b_to_q[v]
 
     def pretty(self, value, record=None):
         if value is True:


### PR DESCRIPTION
Allows labels to have words like "Early/Late" or "Good/Bad", rather than "True/False"

Does not affect the `1`/`0` used in `?q=...`, so all the urls are unchanged.

Also removes a linter warning for the class by replacing mutable function arguments with class arrtibutes.